### PR TITLE
chore: update go to 1.26

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/bjarneo/dotenvjson
 
-go 1.18
+go 1.26
 
-require gopkg.in/yaml.v3 v3.0.1 // indirect
+require gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
updated go to a newer version as the older build (1.3.4) shows up on vulnerability scans. Please merge and release v1.3.5.

Testing:

```
% git log -X | head -1
commit 12a77fff475db6a7fe26362ae3123b65ab1d3459
% cat .env.example | go run .    
{"COMMENT":"wat","DB":"hackers_exposed","DEV_PORT":1337,"DIALECT":"mysql","EMPTY":"","HOST":"db.host","INTERPOLATED":"\"Multiple\\nLines and variable substitution: ${SIMPLE}\"","JSON":"'{\"key\":\"value\",\"nested\":{\"key\":\"value\"},\"number\":1}'","NON_INTERPOLATED":"'raw text without variable interpolation'","PASSWORD":"betterlucknexttime!","PASSWORD_HASH":"pa!@#$%^&*()_+{}|:\"<>?/.,'","PROD_PORT":8080,"STATUS":"production","TRY_ME":"12woop","USER":"root","WOW":"\"such nice # work\""}

```
